### PR TITLE
implement route that returns user's last month of fitbit steps data

### DIFF
--- a/app/coffee/app.coffee
+++ b/app/coffee/app.coffee
@@ -1,6 +1,4 @@
-app = require './server'
-
-###### TO-DO - CHANGE ALL INSTANCES OF COFFEE WITH JS ##########
+app   = require './server'
 port  = require('./config/serverConfig')['port']
 
 app.listen port

--- a/app/coffee/config/middleWare.coffee
+++ b/app/coffee/config/middleWare.coffee
@@ -17,3 +17,10 @@ module.exports =
     # if they aren't redirect them to the home page
     console.log "DEBUG: User not logged in"
     res.send 401
+
+  alreadyLoggedOut: (req, res, next) ->
+    # if user is authenticated in the session, carry on
+    return next()  if req.isAuthenticated()
+
+    # if they aren't redirect them to the home page
+    res.redirect('/');

--- a/app/coffee/config/passport.coffee
+++ b/app/coffee/config/passport.coffee
@@ -125,6 +125,6 @@ module.exports = (passport) ->
 
       # save the user
       user.save (err) ->
-        throw err  if err
+        console.error err  if err
         done null, user
   )

--- a/app/coffee/config/routeHelpers.coffee
+++ b/app/coffee/config/routeHelpers.coffee
@@ -4,6 +4,9 @@ User    = require '../models/user'
 Stats   = require '../models/stat'
 bcrypt  = require 'bcrypt-nodejs'
 uuid    = require 'node-uuid'
+fitbit  = require('fitbit-js')('6b8b28e0569a422e97a70b5ca671df32',
+                               'b351c1fea45d48ed9955a518f4e30e72',
+                               'http://127.0.0.1:3000/fitbit')
 
 module.exports =
 
@@ -45,5 +48,24 @@ module.exports =
   getAll: (req, res) ->
 
   deleteUser: (req, res) ->
+
+  testFitbit: (req, res) ->
+    console.log req.user._id
+    User.findOne
+      "_id": req.user._id
+    , (err, user) ->
+      if err
+        return done err
+      if not user
+        return done null, false
+      # all is well, return successful user
+      else
+        fitbit.apiCall "GET", "/user/-/activities/date/2014-01-20.json",
+          token:
+            oauth_token: user.authData.fitbit.access_token
+            oauth_token_secret: user.authData.fitbit.access_token_secret
+        , (err, resp, json) ->
+          return res.send(err, 500)  if err
+          res.json json
 
 

--- a/app/coffee/config/routeHelpers.coffee
+++ b/app/coffee/config/routeHelpers.coffee
@@ -8,6 +8,18 @@ fitbit  = require('fitbit-js')('6b8b28e0569a422e97a70b5ca671df32',
                                'b351c1fea45d48ed9955a518f4e30e72',
                                'http://127.0.0.1:3000/fitbit')
 
+formatDate = (date) ->
+  year = date.getFullYear()
+  month = parseInt date.getMonth() + 1
+  day = date.getDate()
+  month = '0' + month  if month < 10
+  day = '0' + day  if day < 10
+  "#{year}-#{month}-#{day}"
+
+aMonthAgo = () ->
+  # the date - 30 days (in ms)
+  new Date Date.now()-30*24*60*60*1000
+
 module.exports =
 
   # TO-DO: DECIDE WHAT INDEX ROUTE SHOULD RETURN
@@ -37,36 +49,88 @@ module.exports =
       user++
     res.json data
 
-  signup: (req, res) ->
-
-  login: (req, res) ->
-
   logout: (req, res) ->
+    User.findOne
+      '_id': req.user._id,
+      (err, user) ->
+        if err
+          console.error 'User.findOne error ', err
+        if user
+          user.lastLoggedIn = Date.now()
+          user.save (err) ->
+            console.error err  if err
+        req.logout()
+        res.redirect '/'
 
   getUser: (req, res) ->
-    res.json req.user
+    id = req.params.id
+    res.send 401 if id isnt String req.user._id # can only get logged in user
+    User.findOne
+      '_id': id,
+      (err, user) ->
+        if err
+          console.error 'User.findOne error ', err
+          res.send 500
+        if not user
+          # user isn't in the db
+          res.send 204
+        if user
+          res.json user
 
   getAll: (req, res) ->
+    User.find((err, users) ->
+      if err
+        console.error 'User.find error', err
+        res.send 500
+      res.json users
+    )
 
   deleteUser: (req, res) ->
-
-  testFitbit: (req, res) ->
-    console.log req.user._id
+    id = req.params.id
+    res.send 401 if id isnt String req.user._id # only delete logged-in user
     User.findOne
-      "_id": req.user._id
-    , (err, user) ->
-      if err
-        return done err
-      if not user
-        return done null, false
-      # all is well, return successful user
-      else
-        fitbit.apiCall "GET", "/user/-/activities/date/2014-01-20.json",
-          token:
-            oauth_token: user.authData.fitbit.access_token
-            oauth_token_secret: user.authData.fitbit.access_token_secret
-        , (err, resp, json) ->
-          return res.send(err, 500)  if err
-          res.json json
+      '_id':id,
+      (err, user) ->
+        if err
+          console.error 'User.findOne error', err
+          res.send 500
+        if not user
+          # user is not in DB anyways..
+          res.send 204
+        else
+          user.remove (err, user) -> # remove user record
+            if err
+              console.error 'user.remove error ', err
+              res.send 500
+            req.logout()
+            res.redirect '/'
+
+  fitbitSteps: (req, res) ->
+    id = req.params.id
+    res.send 401 if id isnt String req.user._id # only delete logged-in user
+    User.findOne
+      "_id": id,
+      (err, user) ->
+        if err
+          return done err
+        if not user
+          return done null, false
+        # all is well, return successful user
+        else
+          ##
+          lastMonth = formatDate aMonthAgo()
+          today = formatDate new Date()
+          fitbit.apiCall "GET",
+            "/user/-/activities/steps/date/#{lastMonth}/#{today}.json",
+            token:
+              oauth_token: user.authData.fitbit.access_token
+              oauth_token_secret: user.authData.fitbit.access_token_secret
+          , (err, resp, json) ->
+            return res.send(err, 500)  if err
+            res.json json
+
+  fitbitSubscriptionHandler: (req, res) ->
+    console.log req.body
+    res.send 204
 
 

--- a/app/coffee/config/routeHelpers.coffee
+++ b/app/coffee/config/routeHelpers.coffee
@@ -107,7 +107,7 @@ module.exports =
 
   fitbitSteps: (req, res) ->
     id = req.params.id
-    res.send 401 if id isnt String req.user._id # only delete logged-in user
+    res.send 401 if id isnt String req.user._id # only for logged-in user
     User.findOne
       "_id": id,
       (err, user) ->

--- a/app/coffee/config/routes.coffee
+++ b/app/coffee/config/routes.coffee
@@ -26,8 +26,7 @@ module.exports = (app, passport) ->
   )
 
   #### TO-DO:  FIX THIS DUMMY ROUTE BELOW ####
-  app.get '/profile', isLoggedIn, (req, res) ->
-    res.send('ok')
+  app.get '/profile', isLoggedIn, helper.testFitbit
   
   app.get '/users/:id', helper.getUser
   app.delete '/users/:id', helper.deleteUser

--- a/app/coffee/config/routes.coffee
+++ b/app/coffee/config/routes.coffee
@@ -1,12 +1,12 @@
 # for API and DB endpoints
 helper = require './routeHelpers'
 isLoggedIn = require('./middleWare').isLoggedIn
+alreadyLoggedOut = require('./middleWare').alreadyLoggedOut
 
 module.exports = (app, passport) ->
   app.get '/', helper.index
 
   app.get '/test/data', helper.testData
-  app.get '/users', helper.getAll
 
   app.post '/signup', passport.authenticate('local-signup'), (req, res) ->
     res.json 201, req.user
@@ -14,9 +14,7 @@ module.exports = (app, passport) ->
   app.post '/login', passport.authenticate('local-login'), (req, res) ->
     res.json req.user
 
-  app.get '/logout', (req, res) ->
-    req.logout()
-    res.redirect '/'
+  app.get '/logout', alreadyLoggedOut, helper.logout
 
 ## FITBIT AUTHORIZATION ###
   app.get '/connect/fitbit', isLoggedIn ,passport.authenticate('fitbit')
@@ -25,8 +23,10 @@ module.exports = (app, passport) ->
     successRedirect: '#/connect-devices'
   )
 
-  #### TO-DO:  FIX THIS DUMMY ROUTE BELOW ####
-  app.get '/profile', isLoggedIn, helper.testFitbit
-  
-  app.get '/users/:id', helper.getUser
-  app.delete '/users/:id', helper.deleteUser
+  app.get '/users', isLoggedIn, helper.getAll
+  app.get '/users/:id', isLoggedIn, helper.getUser
+  app.delete '/users/:id', isLoggedIn, helper.deleteUser
+  app.get '/users/:id/fitbit/steps', isLoggedIn, helper.fitbitSteps
+
+
+  app.post '/fitbitUpdate', helper.fitbitSubscriptionHandler

--- a/app/coffee/config/routes.coffee
+++ b/app/coffee/config/routes.coffee
@@ -22,10 +22,8 @@ module.exports = (app, passport) ->
   app.get '/connect/fitbit', isLoggedIn ,passport.authenticate('fitbit')
   app.get '/connect/fitbit/callback', isLoggedIn, passport.authenticate('fitbit',
     failureRedirect: '/login'
-  ), (req, res) ->
-    res.json req.user
-    # Successful authentication, redirect home.
-    # res.redirect '/'
+    successRedirect: '#/connect-devices'
+  )
 
   #### TO-DO:  FIX THIS DUMMY ROUTE BELOW ####
   app.get '/profile', isLoggedIn, (req, res) ->

--- a/app/coffee/models/user.coffee
+++ b/app/coffee/models/user.coffee
@@ -22,6 +22,8 @@ UserSchema = new mongoose.Schema(
     type: Date
     default: Date.now
 
+  lastLoggedIn: Date
+
   authData:
 
     fitbit:

--- a/app/coffee/server.coffee
+++ b/app/coffee/server.coffee
@@ -1,13 +1,11 @@
 # requiring dependencies
 
-express = require 'express'
-mongoose = require 'mongoose'
-passport = require 'passport'
-
-###### TO-DO - CHANGE ALL INSTANCES OF COFFEE WITH JS ##########
-cors = require './config/middleWare'
+express     = require 'express'
+mongoose    = require 'mongoose'
+passport    = require 'passport'
+cors        = require './config/middleWare'
 mongoConfig = require './config/dbconfig'
-port  = require('./config/serverConfig')['port']
+port        = require('./config/serverConfig')['port']
 
 # connect to DB
 mongoose.connect mongoConfig.url


### PR DESCRIPTION
At the moment, it makes an on-demand call to Fitbit's API and returns back a blob of the last month's steps data.

This commit includes the following working routes:
GET '/users', Gets all users' info.  Will probably not keep this around...
GET '/users/:id', Gets user's info specified by the id, at the moment, id must match current logged in user's id
DELETE '/users/:id', Deletes user info specified by the id, at the moment, id must match current logged in user's id
GET '/users/:id/fitbit/steps', Get last month's fitbit steps data for the user specified by the id, at the moment, id must match current logged in user's id
